### PR TITLE
Potential fix for code scanning alert no. 1: Dependency download using unencrypted communication channel

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 gem "json", ">= 2.3.0"
 gem "sinatra", ">= 4.1.0"
 gem 'flickraw'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     base64 (0.2.0)
     flickraw (0.9.10)


### PR DESCRIPTION
Potential fix for [https://github.com/meatcoder/random-flickr/security/code-scanning/1](https://github.com/meatcoder/random-flickr/security/code-scanning/1)

To fix the issue, the protocol in the source URL should be changed from `http` to `https`. This ensures that the communication channel used to download dependencies is encrypted and secure. The change is straightforward and involves modifying the first line of the `Gemfile` to use `https://rubygems.org` instead of `http://rubygems.org`. This fix does not alter the functionality of the code but ensures that the dependency download process is secure.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
